### PR TITLE
Serialization now works with plain \psi nugets

### DIFF
--- a/DynamicSerializers.cs
+++ b/DynamicSerializers.cs
@@ -26,10 +26,9 @@ namespace RosBagConverter
             Generators.Sequence(pipeline, messages.Select(m => ((T)m.Item1, m.Item2))).Write(topic, store);
         }
 
-        public static void Write(Pipeline pipeline, string topic, IEnumerable<(dynamic, DateTime)> messages, Exporter store)
+        public static void WriteDynamic(Pipeline pipeline, string topic, IEnumerable<(dynamic, DateTime)> messages, Exporter store)
         {
-            var first = messages.First();
-            switch (first.Item1)
+            switch (messages.First().Item1)
             {
                 case string _:
                     WriteStronglyTyped<string>(pipeline, topic, messages, store);
@@ -39,6 +38,9 @@ namespace RosBagConverter
                     break;
                 case byte _:
                     WriteStronglyTyped<byte>(pipeline, topic, messages, store);
+                    break;
+                case sbyte _:
+                    WriteStronglyTyped<sbyte>(pipeline, topic, messages, store);
                     break;
                 case short _:
                     WriteStronglyTyped<short>(pipeline, topic, messages, store);
@@ -63,12 +65,6 @@ namespace RosBagConverter
                     break;
                 case double _:
                     WriteStronglyTyped<double>(pipeline, topic, messages, store);
-                    break;
-                case RosTime _:
-                    WriteStronglyTyped<RosTime>(pipeline, topic, messages, store);
-                    break;
-                case RosDuration _:
-                    WriteStronglyTyped<RosDuration>(pipeline, topic, messages, store);
                     break;
             }
         }
@@ -171,13 +167,13 @@ namespace RosBagConverter
                 case ("float64"):
                 case ("string"):
                 case ("bool"):
-                    Write(pipeline, streamName, messages.Select(m => (m.GetField(fieldName), m.Time.ToDateTime())), store);
+                    WriteDynamic(pipeline, streamName, messages.Select(m => (m.GetField(fieldName), m.Time.ToDateTime())), store);
                     return;
                 case ("time"):
-                    Write(pipeline, streamName, messages.Select(m => ((dynamic)((RosTime)m.GetField(fieldName)).ToDateTime(), m.Time.ToDateTime())), store);
+                    WriteStronglyTyped<RosTime>(pipeline, streamName, messages.Select(m => ((dynamic)((RosTime)m.GetField(fieldName)).ToDateTime(), m.Time.ToDateTime())), store);
                     return;
                 case ("duration"):
-                    Write(pipeline, streamName, messages.Select(m => ((dynamic)((RosDuration)m.GetField(fieldName)).ToTimeSpan(), m.Time.ToDateTime())), store);
+                    WriteStronglyTyped<RosTime>(pipeline, streamName, messages.Select(m => ((dynamic)((RosDuration)m.GetField(fieldName)).ToTimeSpan(), m.Time.ToDateTime())), store);
                     return;
             }
 
@@ -190,7 +186,7 @@ namespace RosBagConverter
                     case ("uint8"):
                     case ("int32"):
                     case ("float64"):
-                        Write(pipeline, streamName, messages.Select(m => ((dynamic)m.GetField(fieldName), m.Time.ToDateTime())), store);
+                        WriteDynamic(pipeline, streamName, messages.Select(m => ((dynamic)m.GetField(fieldName), m.Time.ToDateTime())), store);
                         return;
                 }
             }

--- a/DynamicSerializers.cs
+++ b/DynamicSerializers.cs
@@ -23,6 +23,7 @@ namespace RosBagConverter
 
         private static void WriteStronglyTyped<T>(Pipeline pipeline, string topic, IEnumerable<(dynamic, DateTime)> messages, Exporter store)
         {
+            Console.WriteLine($"Stream: {topic} ({typeof(T)})");
             Generators.Sequence(pipeline, messages.Select(m => ((T)m.Item1, m.Item2))).Write(topic, store);
         }
 
@@ -65,6 +66,12 @@ namespace RosBagConverter
                     break;
                 case double _:
                     WriteStronglyTyped<double>(pipeline, topic, messages, store);
+                    break;
+                case RosTime _:
+                    WriteStronglyTyped<RosTime>(pipeline, topic, messages, store);
+                    break;
+                case RosDuration _:
+                    WriteStronglyTyped<RosDuration>(pipeline, topic, messages, store);
                     break;
             }
         }
@@ -170,10 +177,10 @@ namespace RosBagConverter
                     WriteDynamic(pipeline, streamName, messages.Select(m => (m.GetField(fieldName), m.Time.ToDateTime())), store);
                     return;
                 case ("time"):
-                    WriteStronglyTyped<RosTime>(pipeline, streamName, messages.Select(m => ((dynamic)((RosTime)m.GetField(fieldName)).ToDateTime(), m.Time.ToDateTime())), store);
+                    WriteDynamic(pipeline, streamName, messages.Select(m => ((dynamic)((RosTime)m.GetField(fieldName)).ToDateTime(), m.Time.ToDateTime())), store);
                     return;
                 case ("duration"):
-                    WriteStronglyTyped<RosTime>(pipeline, streamName, messages.Select(m => ((dynamic)((RosDuration)m.GetField(fieldName)).ToTimeSpan(), m.Time.ToDateTime())), store);
+                    WriteDynamic(pipeline, streamName, messages.Select(m => ((dynamic)((RosDuration)m.GetField(fieldName)).ToTimeSpan(), m.Time.ToDateTime())), store);
                     return;
             }
 

--- a/MessageSerializers/SensorMsgsSerializer.cs
+++ b/MessageSerializers/SensorMsgsSerializer.cs
@@ -19,7 +19,7 @@ namespace RosBagConverter.MessageSerializers
             switch (messageType)
             {
                 case ("sensor_msgs/Image"):
-                    DynamicSerializers.Write(pipeline, streamName, messages.Select(m => (this.RosMessageToPsiImage(m), m.Time.ToDateTime())), store);
+                    DynamicSerializers.WriteDynamic(pipeline, streamName, messages.Select(m => (this.RosMessageToPsiImage(m), m.Time.ToDateTime())), store);
                     return true;
                 default: return false;
             }

--- a/MessageSerializers/StdMsgsSerializers.cs
+++ b/MessageSerializers/StdMsgsSerializers.cs
@@ -28,7 +28,7 @@ namespace RosBagConverter.MessageSerializers
                 case "std_msgs/Float64":
                 case "std_msgs/String":
                 case "std_msgs/Bool":
-                    DynamicSerializers.Write(pipeline, streamName, messages.Select(m => (m.GetField("data"), m.Time.ToDateTime())), store);
+                    DynamicSerializers.WriteDynamic(pipeline, streamName, messages.Select(m => (m.GetField("data"), m.Time.ToDateTime())), store);
                     return true;
                 default: return false;
             }

--- a/MessageSerializers/StdMsgsSerializers.cs
+++ b/MessageSerializers/StdMsgsSerializers.cs
@@ -1,102 +1,37 @@
-﻿using Microsoft.Psi;
-using Microsoft.Psi.Common;
-using Microsoft.Psi.Persistence;
-using Microsoft.Psi.Serialization;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Psi;
+using Microsoft.Psi.Data;
 
 namespace RosBagConverter.MessageSerializers
 {
     public class StdMsgsSerializers
     {
-        private KnownSerializers serializers = new KnownSerializers();
-        private SerializationContext context = new SerializationContext();
-
-        public StdMsgsSerializers(KnownSerializers serializers = null)
+        public StdMsgsSerializers()
         {
             // TODO I wanted everyone to share a serializer but somehow they currently randomly get deconstructed.
         }
 
-        private void WriteToStore(StoreWriter store, BufferWriter dataBuffer, RosMessage message, int streamId, int msgNum)
+        public bool SerializeMessage(Pipeline pipeline, Exporter store, string streamName, List<RosMessage> messages, string messageType)
         {
-            var envelope = new Envelope(message.Time.ToDateTime(), message.Time.ToDateTime(), streamId, msgNum);
-            store.Write(new BufferReader(dataBuffer), envelope);
-        }
-
-        public bool SerializeMessage(StoreWriter store, string streamName, List<RosMessage> messages, int streamId)
-        {
-            string messageType = messages.FirstOrDefault()?.MessageType.Type;
-            BufferWriter dataBuffer = new BufferWriter(128);
-
             switch (messageType)
             {
-                case ("std_msgs/Int8"):
-                case ("std_msgs/UInt8"):
-                case ("std_msgs/Int16"):
-                case ("std_msgs/UInt16"):
-                case ("std_msgs/Int32"):
-                case ("std_msgs/UInt32"):
-                    var intSerializer = this.serializers.GetHandler<int>();
-                    store.OpenStream(streamId, streamName, true, intSerializer.Name);
-                    for (var i = 0; i < messages.Count; i++)
-                    {
-                        context.Reset();
-                        dataBuffer.Reset();
-                        intSerializer.Serialize(dataBuffer, (int)messages[i].GetField("data"), context);
-                        this.WriteToStore(store, dataBuffer, messages[i], streamId, i);
-                    }
+                case "std_msgs/Int8":
+                case "std_msgs/UInt8":
+                case "std_msgs/Int16":
+                case "std_msgs/UInt16":
+                case "std_msgs/Int32":
+                case "std_msgs/UInt32":
+                case "std_msgs/Int64":
+                case "std_msgs/UInt64":
+                case "std_msgs/Float32":
+                case "std_msgs/Float64":
+                case "std_msgs/String":
+                case "std_msgs/Bool":
+                    DynamicSerializers.Write(pipeline, streamName, messages.Select(m => (m.GetField("data"), m.Time.ToDateTime())), store);
                     return true;
-                case ("std_msgs/Int64"):
-                case ("std_msgs/UInt64"):
-                    var longSerializer = this.serializers.GetHandler<long>();
-                    store.OpenStream(streamId, streamName, true, longSerializer.Name);
-                    for (var i = 0; i < messages.Count; i++)
-                    {
-                        context.Reset();
-                        dataBuffer.Reset();
-                        longSerializer.Serialize(dataBuffer, (long)messages[i].GetField("data"), context);
-                        this.WriteToStore(store, dataBuffer, messages[i], streamId, i);
-                    }
-                    return true;
-                case ("std_msgs/Float32"):
-                case ("std_msgs/Float64"):
-                    var doubleSerializer = this.serializers.GetHandler<double>();
-                    store.OpenStream(streamId, streamName, true, doubleSerializer.Name);
-                    for (var i = 0; i < messages.Count; i++)
-                    {
-                        context.Reset();
-                        dataBuffer.Reset();
-                        doubleSerializer.Serialize(dataBuffer, (double)messages[i].GetField("data"), context);
-                        this.WriteToStore(store, dataBuffer, messages[i], streamId, i);
-                    }
-                    return true;
-                case ("std_msgs/String"):
-                    var stringSerializer = this.serializers.GetHandler<string>();
-                    store.OpenStream(streamId, streamName, true, stringSerializer.Name);
-                    for (var i = 0; i < messages.Count; i++)
-                    {
-                        context.Reset();
-                        dataBuffer.Reset();
-                        stringSerializer.Serialize(dataBuffer, (string)messages[i].GetField("data"), context);
-                        this.WriteToStore(store, dataBuffer, messages[i], streamId, i);
-                    }
-                    return true;
-                case ("std_msgs/Bool"):
-                    var boolSerializer = this.serializers.GetHandler<bool>();
-                    store.OpenStream(streamId, streamName, true, boolSerializer.Name);
-                    for (var i = 0; i < messages.Count; i++)
-                    {
-                        context.Reset();
-                        dataBuffer.Reset();
-                        boolSerializer.Serialize(dataBuffer, (bool)messages[i].GetField("data"), context);
-                        this.WriteToStore(store, dataBuffer, messages[i], streamId, i);
-                    }
-                    return true;
+                default: return false;
             }
-            return false;
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Psi;
-using Microsoft.Psi.Common;
-using Microsoft.Psi.Persistence;
-using Microsoft.Psi.Serialization;
 using CommandLine;
 
 namespace RosBagConverter
@@ -35,25 +29,22 @@ namespace RosBagConverter
         private static int ConvertBag(Verbs.ConvertOptions opts)
         {
             var bag = new RosBag(opts.Input);
-            IEnumerable<string> topicList;
-            if (opts.Topics.Count() > 0)
-            {
-                topicList = opts.Topics;
-            }
-            else
-            {
-                topicList = bag.TopicList;
-            }
+            var topicList = opts.Topics.Count() > 0 ? opts.Topics : bag.TopicList;
             // create a psi store
-            var store = new StoreWriter(opts.Name, opts.Output);
-            var dynamicSerializer = new DynamicSerializers(bag.KnownRosMessageDefinitions);
 
-            foreach (var topic in topicList)
+            using (var pipeline = Pipeline.Create())
             {
-                var topicDefinition = bag.GetMessageDefinition(topic);
-                var messages = bag.ReadTopic(topic);
-                dynamicSerializer.SerializeMessage(store, topic, messages);
+                var store = Store.Create(pipeline, opts.Name, opts.Output);
+                var dynamicSerializer = new DynamicSerializers(bag.KnownRosMessageDefinitions);
+                foreach (var topic in topicList)
+                {
+                    var messages = bag.ReadTopic(topic);
+                    dynamicSerializer.SerializeMessages(pipeline, store, topic, messages);
+                }
+
+                pipeline.Run();
             }
+
             return 1;
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -30,8 +30,8 @@ namespace RosBagConverter
         {
             var bag = new RosBag(opts.Input);
             var topicList = opts.Topics.Count() > 0 ? opts.Topics : bag.TopicList;
-            // create a psi store
 
+            // create a psi store
             using (var pipeline = Pipeline.Create())
             {
                 var store = Store.Create(pipeline, opts.Name, opts.Output);

--- a/README.md
+++ b/README.md
@@ -12,20 +12,18 @@ Some properties of the tool:
 * For standard messsages not implemented or custom ros messages, the tool deconstruct them into their [ros message built-in types](http://wiki.ros.org/msg)
 
 ## Installation
-1. To build the tool, you need the source version of [Platform for Situated Intelligence](https://github.com/microsoft/psi).
-2. Add this project to the solution (Suggested location is Psi\Samples).
-3. Edit ``psi\Sources\Runtime\Microsoft.Psi\Serialization\KnownSerializers.cs`` and change the method `GetHandler<T>()` from internal to public. You will also need to disable the warning.
-```
-#pragma warning disable SA1600 // Elements should be documented
-        public SerializationHandler<T> GetHandler<T>()
-#pragma warning restore SA1600 // Elements should be documented
-```
-4. Build the tool.
+
+The tool depends on the [Platform for Situated Intelligence](https://github.com/microsoft/psi) which is installed upon first build.
+Open `RosBagConverter.sln` and Build Solution.
 
 ## Usage
+
 To use the tool, open the commandline tool and navigate to where the executable is. Our goal is to eventually provide the same functionalities as those in [rosbag tools](http://wiki.ros.org/bag_tools).
 
+If you need some test data, try running through the [Recording and playing back data](http://wiki.ros.org/rosbag/Tutorials/Recording%20and%20playing%20back%20data) tutorial, then `RosBagConverter.exe convert -f <my_path>\turtle.bag -o <my_path> -n Turtle`
+
 #### Info
+
 `RosBagConverter.exe info`
 This list out the topics in the given RosBag. 
 ```

--- a/RosBagConverter.csproj
+++ b/RosBagConverter.csproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFramework>net472</TargetFramework>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.0.0-beta</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/RosBagConverter.csproj
+++ b/RosBagConverter.csproj
@@ -9,10 +9,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\psi\Sources\Imaging\Microsoft.Psi.Imaging\Microsoft.Psi.Imaging.csproj" />
-    <ProjectReference Include="..\psi\Sources\Runtime\Microsoft.Psi\Microsoft.Psi.csproj" />
+    <PackageReference Include="Microsoft.Psi.Imaging" Version="0.10.16.1-beta" />
+    <PackageReference Include="Microsoft.Psi.Runtime" Version="0.10.16.1-beta" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/RosMessageDefinition.cs
+++ b/RosMessageDefinition.cs
@@ -157,7 +157,7 @@ namespace RosBagConverter
                 case "uint16":
                 case "int32":
                 case "uint32":
-                case "flaot32":
+                case "float32":
                 case "time":
                 case "duration":
                 case "int64":
@@ -198,7 +198,7 @@ namespace RosBagConverter
                     return 2;
                 case "int32":
                 case "uint32":
-                case "flaot32":
+                case "float32":
                     return 4;
                 case "time":
                 case "duration":


### PR DESCRIPTION
Made serialization work without intimate knowledge of (and changes to) the guts of \psi serialization. Changed to create proper \psi streams and serialize them by spinning up a `Pipeline` and writing via an `Exporter`.